### PR TITLE
Add configuration defaults for dev server host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,17 +134,28 @@ like `/packs//packs/application-2ea8c3891d.css`).
 ### Using with a dev server
 
 You may also connect the `external_asset_pipeline` to a dev server (e.g.
-[`webpack-dev-server`]). To do so, configure the corresponding `dev_server`
-settings:
+[`webpack-dev-server`]). To do so, enable the `dev_server` in the relevant
+environments:
 
 ```ruby
 config.external_asset_pipeline.dev_server.enabled = true
-config.external_asset_pipeline.dev_server.host = 'localhost'
+```
+
+You may also optionally configure the `dev_server` `host` and `port` (their
+default values are `'localhost'` and `3035`, respectively):
+
+```ruby
+config.external_asset_pipeline.dev_server.host = 'dev-server'
 config.external_asset_pipeline.dev_server.port = 9000
 ```
 
-You may _optionally_ also configure the `dev_server.public_origin` setting,
-which will be used to generate the URLs in your asset tags. If this isn't set,
+Finally, you may optionally configure the `dev_server.public_origin` setting:
+
+```ruby
+config.external_asset_pipeline.dev_server.public_origin = 'http://localhost:9000'
+```
+
+This will be used to generate the URLs in your asset tags. If this isn't set,
 the asset origin defaults to `"http://#{dev_server.host}:#{dev_server.port}"`,
 so `public_origin` only needs to be set if that default doesn't work <sup>1</sup>.
 

--- a/examples/demo_app-rails5/config/environments/development.rb
+++ b/examples/demo_app-rails5/config/environments/development.rb
@@ -57,7 +57,6 @@ Rails.application.configure do
 
   # Enable the external asset pipeline dev server.
   config.external_asset_pipeline.dev_server.enabled = true
-  config.external_asset_pipeline.dev_server.host = 'localhost'
   config.external_asset_pipeline.dev_server.port = 9000
 
   # Raises error for missing translations

--- a/examples/demo_app/config/environments/development.rb
+++ b/examples/demo_app/config/environments/development.rb
@@ -58,7 +58,6 @@ Rails.application.configure do
 
   # Enable the external asset pipeline dev server.
   config.external_asset_pipeline.dev_server.enabled = true
-  config.external_asset_pipeline.dev_server.host = 'localhost'
   config.external_asset_pipeline.dev_server.port = 9000
 
   # Raises error for missing translations.

--- a/lib/external_asset_pipeline/configuration.rb
+++ b/lib/external_asset_pipeline/configuration.rb
@@ -25,6 +25,7 @@ module ExternalAssetPipeline
 
       def initialize
         @connect_timeout = 0.01
+        @host = 'localhost'
       end
     end
 

--- a/lib/external_asset_pipeline/configuration.rb
+++ b/lib/external_asset_pipeline/configuration.rb
@@ -26,6 +26,7 @@ module ExternalAssetPipeline
       def initialize
         @connect_timeout = 0.01
         @host = 'localhost'
+        @port = 3035
       end
     end
 

--- a/test/external_asset_pipeline/configuration_test.rb
+++ b/test/external_asset_pipeline/configuration_test.rb
@@ -47,7 +47,7 @@ module ExternalAssetPipeline
       assert_equal 0.01, config.dev_server.connect_timeout
       assert_nil config.dev_server.enabled
       assert_equal 'localhost', config.dev_server.host
-      assert_nil config.dev_server.port
+      assert_equal 3035, config.dev_server.port
       assert_nil config.dev_server.public_origin
 
       config.configure do |c|

--- a/test/external_asset_pipeline/configuration_test.rb
+++ b/test/external_asset_pipeline/configuration_test.rb
@@ -46,21 +46,21 @@ module ExternalAssetPipeline
 
       assert_equal 0.01, config.dev_server.connect_timeout
       assert_nil config.dev_server.enabled
-      assert_nil config.dev_server.host
+      assert_equal 'localhost', config.dev_server.host
       assert_nil config.dev_server.port
       assert_nil config.dev_server.public_origin
 
       config.configure do |c|
         c.dev_server.connect_timeout = 0.5
         c.dev_server.enabled = true
-        c.dev_server.host = 'localhost'
+        c.dev_server.host = 'assets.localhost'
         c.dev_server.port = 9000
         c.dev_server.public_origin = 'http://example-app.test'
       end
 
       assert_equal 0.5, config.dev_server.connect_timeout
       assert_equal true, config.dev_server.enabled
-      assert_equal 'localhost', config.dev_server.host
+      assert_equal 'assets.localhost', config.dev_server.host
       assert_equal 9000, config.dev_server.port
       assert_equal 'http://example-app.test', config.dev_server.public_origin
     end


### PR DESCRIPTION
The most common dev server host is `'localhost'`. Additionally, the Content Security Policy initializer that rails generates [suggests a dev server port of `3035`](https://github.com/rails/rails/blob/v6.0.0/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt#L15-L16). By making these the configuration defaults, there is less to configure in apps that align with these established conventions.