### PR TITLE
Add separate version constants

### DIFF
--- a/external_asset_pipeline.gemspec
+++ b/external_asset_pipeline.gemspec
@@ -6,7 +6,7 @@ require 'external_asset_pipeline/version'
 
 Gem::Specification.new do |s|
   s.name     = 'external_asset_pipeline'
-  s.version  = ExternalAssetPipeline::VERSION
+  s.version  = ExternalAssetPipeline::VERSION::STRING
   s.authors  = ['Richard Macklin']
   s.email    = ['1863540+rmacklin@users.noreply.github.com']
   s.homepage = 'https://github.com/rails-front-end/external_asset_pipeline'
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
 
   s.metadata['homepage_uri'] = s.homepage
   s.metadata['source_code_uri'] =
-    "#{s.homepage}/tree/v#{ExternalAssetPipeline::VERSION}"
+    "#{s.homepage}/tree/v#{ExternalAssetPipeline::VERSION::STRING}"
   s.metadata['changelog_uri'] =
-    "#{s.homepage}/blob/v#{ExternalAssetPipeline::VERSION}/CHANGELOG.md"
+    "#{s.homepage}/blob/v#{ExternalAssetPipeline::VERSION::STRING}/CHANGELOG.md"
 
   s.files = Dir['{lib}/**/*']
   s.require_paths = ['lib']

--- a/lib/external_asset_pipeline/version.rb
+++ b/lib/external_asset_pipeline/version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module ExternalAssetPipeline
-  VERSION = '0.6.0'
+  module VERSION
+    STRING = '0.6.0'
+  end
 end

--- a/lib/external_asset_pipeline/version.rb
+++ b/lib/external_asset_pipeline/version.rb
@@ -6,6 +6,6 @@ module ExternalAssetPipeline
     MINOR = 6
     PATCH = 0
 
-    STRING = '0.6.0'
+    STRING = [MAJOR, MINOR, PATCH].join('.')
   end
 end

--- a/lib/external_asset_pipeline/version.rb
+++ b/lib/external_asset_pipeline/version.rb
@@ -2,6 +2,10 @@
 
 module ExternalAssetPipeline
   module VERSION
+    MAJOR = 0
+    MINOR = 6
+    PATCH = 0
+
     STRING = '0.6.0'
   end
 end

--- a/test/external_asset_pipeline_test.rb
+++ b/test/external_asset_pipeline_test.rb
@@ -11,8 +11,12 @@ class ExternalAssetPipelineTest < Minitest::Test
     refute_nil ::ExternalAssetPipeline::VERSION::PATCH
     assert_kind_of Integer, ::ExternalAssetPipeline::VERSION::PATCH
 
-    refute_nil ::ExternalAssetPipeline::VERSION::STRING
-    assert_kind_of String, ::ExternalAssetPipeline::VERSION::STRING
+    version_string = [
+      ::ExternalAssetPipeline::VERSION::MAJOR,
+      ::ExternalAssetPipeline::VERSION::MINOR,
+      ::ExternalAssetPipeline::VERSION::PATCH
+    ].join('.')
+    assert_equal version_string, ::ExternalAssetPipeline::VERSION::STRING
   end
 
   def test_that_manifest_can_be_set

--- a/test/external_asset_pipeline_test.rb
+++ b/test/external_asset_pipeline_test.rb
@@ -4,6 +4,13 @@ require 'test_helper'
 
 class ExternalAssetPipelineTest < Minitest::Test
   def test_that_it_has_a_version_number
+    refute_nil ::ExternalAssetPipeline::VERSION::MAJOR
+    assert_kind_of Integer, ::ExternalAssetPipeline::VERSION::MAJOR
+    refute_nil ::ExternalAssetPipeline::VERSION::MINOR
+    assert_kind_of Integer, ::ExternalAssetPipeline::VERSION::MINOR
+    refute_nil ::ExternalAssetPipeline::VERSION::PATCH
+    assert_kind_of Integer, ::ExternalAssetPipeline::VERSION::PATCH
+
     refute_nil ::ExternalAssetPipeline::VERSION::STRING
     assert_kind_of String, ::ExternalAssetPipeline::VERSION::STRING
   end

--- a/test/external_asset_pipeline_test.rb
+++ b/test/external_asset_pipeline_test.rb
@@ -4,7 +4,8 @@ require 'test_helper'
 
 class ExternalAssetPipelineTest < Minitest::Test
   def test_that_it_has_a_version_number
-    refute_nil ::ExternalAssetPipeline::VERSION
+    refute_nil ::ExternalAssetPipeline::VERSION::STRING
+    assert_kind_of String, ::ExternalAssetPipeline::VERSION::STRING
   end
 
   def test_that_manifest_can_be_set


### PR DESCRIPTION
This PR adds `ExternalAssetPipeline::VERSION::MAJOR`, `ExternalAssetPipeline::VERSION::MINOR`, and `ExternalAssetPipeline::VERSION::PATCH` constants and renames `ExternalAssetPipeline::VERSION` to `ExternalAssetPipeline::VERSION::STRING`.

Adding these constants allows for more fine-grained programmatic access (for example, you can now write comparisons involving just `ExternalAssetPipeline::VERSION::MAJOR`, instead of having to parse it out of `ExternalAssetPipeline::VERSION::STRING`.

This was inspired by Rails:
https://github.com/rails/rails/blob/cd30ec1fe54115016d9337b9fa1ba44697ffd017/version.rb