### PR TITLE
Bump patch version of es-abstract dependency in demo_app-brunch example app

### DIFF
--- a/examples/demo_app-brunch/yarn.lock
+++ b/examples/demo_app-brunch/yarn.lock
@@ -1786,9 +1786,9 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.6.1:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.0.tgz#f59d9d44278ea8f90c8ff3de1552537c2fd739b4"
-  integrity sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.1.tgz#6e8d84b445ec9c610781e74a6d52cc31aac5b4ca"
+  integrity sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==
   dependencies:
     es-to-primitive "^1.2.0"
     function-bind "^1.1.1"


### PR DESCRIPTION
Version 1.14.0 has been removed from the npm registry (https://github.com/ljharb/es-abstract/issues/55), so `yarn install` was failing with:
```
error An unexpected error occurred: "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.0.tgz: Request failed \"404 Not Found\"".
```
Upgrading to 1.14.1 fixes this.