### PR TITLE
Update rubocop configuration to support the latest release (v0.85.1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,12 @@
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.5.5
   Exclude:
     - examples/**/*
     - vendor/bundle/**/*
+
+Layout/LineLength:
+  Max: 80
 
 Style/Documentation:
   Enabled: false

--- a/test/external_asset_pipeline/manifest_test.rb
+++ b/test/external_asset_pipeline/manifest_test.rb
@@ -97,11 +97,11 @@ module ExternalAssetPipeline
     private
 
     def modify_application_js_fingerprint(manifest_path)
-      `sed -i'.bak' -e 's/7b3dc2436f7956c77987/22222222222222222222/g' #{manifest_path}` # rubocop:disable Metrics/LineLength
+      `sed -i'.bak' -e 's/7b3dc2436f7956c77987/22222222222222222222/g' #{manifest_path}` # rubocop:disable Layout/LineLength
     end
 
     def revert_application_js_fingerprint(manifest_path)
-      `sed -i'.bak' -e 's/22222222222222222222/7b3dc2436f7956c77987/g' #{manifest_path}` # rubocop:disable Metrics/LineLength
+      `sed -i'.bak' -e 's/22222222222222222222/7b3dc2436f7956c77987/g' #{manifest_path}` # rubocop:disable Layout/LineLength
       `rm #{manifest_path}.bak`
     end
   end


### PR DESCRIPTION
The Metrics/LineLength cop was moved to Layout/LineLength, and its default value for the `Max` attribute was changed from 80 to 120. We're going to stick to 80 for now, though (may revisit later).

Additionally, we've set `NewCops: enable` to opt into new cops. If this becomes a pain we can instead switch to enabling individual cops, but for now we'd like to stay as close to the default style guide as possible.