### PR TITLE
Update documentation and examples for rails 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Or install it yourself as:
 
 ## Usage
 
-In `config/application.rb`, after the code that `require`s rails, add:
+In `config/application.rb`, after `Bundler.require(*Rails.groups)`, add:
 
 ```ruby
 require 'external_asset_pipeline/railtie'

--- a/examples/demo_app-brunch/config/application.rb
+++ b/examples/demo_app-brunch/config/application.rb
@@ -14,11 +14,11 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
 
-require "external_asset_pipeline/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require "external_asset_pipeline/railtie"
 
 module DemoApp
   class Application < Rails::Application

--- a/examples/demo_app-gulp-alt/config/application.rb
+++ b/examples/demo_app-gulp-alt/config/application.rb
@@ -14,11 +14,11 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
 
-require "external_asset_pipeline/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require "external_asset_pipeline/railtie"
 
 module DemoApp
   class << self

--- a/examples/demo_app-gulp/config/application.rb
+++ b/examples/demo_app-gulp/config/application.rb
@@ -14,11 +14,11 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
 
-require "external_asset_pipeline/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require "external_asset_pipeline/railtie"
 
 module DemoApp
   class Application < Rails::Application

--- a/examples/demo_app-rails5/config/application.rb
+++ b/examples/demo_app-rails5/config/application.rb
@@ -2,11 +2,11 @@ require_relative 'boot'
 
 require 'rails/all'
 
-require 'external_asset_pipeline/railtie'
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require 'external_asset_pipeline/railtie'
 
 module DemoApp
   class Application < Rails::Application

--- a/examples/demo_app-rollup/config/application.rb
+++ b/examples/demo_app-rollup/config/application.rb
@@ -2,11 +2,11 @@ require_relative "boot"
 
 require "rails/all"
 
-require "external_asset_pipeline/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require "external_asset_pipeline/railtie"
 
 module DemoApp
   class Application < Rails::Application

--- a/examples/demo_app/config/application.rb
+++ b/examples/demo_app/config/application.rb
@@ -2,11 +2,11 @@ require_relative "boot"
 
 require "rails/all"
 
-require "external_asset_pipeline/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require "external_asset_pipeline/railtie"
 
 module DemoApp
   class Application < Rails::Application


### PR DESCRIPTION
Follow-up to #192

It's important that the ExternalAssetPipeline railtie is loaded *after* the Sprockets railtie in an application that uses Sprockets. Otherwise, the `compute_asset_path` method from sprockets-rails will be invoked prior to the one from `ExternalAssetPipeline::Helper`, which will lead to an error when it attempts to resolve assets from the external asset pipeline.

In Rails 7.0 (and beyond) sprockets-rails is no longer an explicit dependency, so its railtie will be loaded via `Bundler.require(*Rails.groups)` (rather than via `require "rails/all"`) when sprockets-rails (or a gem which depends on sprockets-rails) is explicitly declared in the `Gemfile`. Thus, we should place our `require "external_asset_pipeline/railtie"` after `Bundler.require(*Rails.groups)` so that it'll take precedence over sprockets-rails no matter which version of rails is used. This PR updates the README instructions and the example apps accordingly.